### PR TITLE
Updated FieldName validation logic

### DIFF
--- a/src/Rested.Core.Data/Search/ISearchResults.cs
+++ b/src/Rested.Core.Data/Search/ISearchResults.cs
@@ -8,6 +8,6 @@ public interface ISearchResults<TResult>
     List<TResult> Items { get; set; }
     int PageSize { get; set; }
     int Page { get; set; }
-    List<FieldSortInfo> SortingFields { get; set; }
-    List<IFilter> Filters { get; set; }
+    List<FieldSortInfo>? SortingFields { get; set; }
+    List<IFilter>? Filters { get; set; }
 }

--- a/src/Rested.Core.Data/Search/SearchRequest.cs
+++ b/src/Rested.Core.Data/Search/SearchRequest.cs
@@ -4,6 +4,6 @@ public record SearchRequest
 {
     public virtual int PageSize { get; set; }
     public int Page { get; set; } = 1;
-    public List<FieldSortInfo> SortingFields { get; set; }
-    public List<IFilter> Filters { get; set; }
+    public List<FieldSortInfo>? SortingFields { get; set; }
+    public List<IFilter>? Filters { get; set; }
 }

--- a/src/Rested.Core.MediatR/Queries/SearchQuery.cs
+++ b/src/Rested.Core.MediatR/Queries/SearchQuery.cs
@@ -155,7 +155,9 @@ public abstract class SearchQueryHandler<TResultType, TSearchResults, TSearchQue
 
     protected virtual void OnBeginHandle(TSearchQuery query) { }
 
-    protected virtual List<IFilter> GetImplicitFilters() => new();
+    protected virtual List<FieldSortInfo> GetImplicitSortingFields() => [];
+    
+    protected virtual List<IFilter> GetImplicitFilters() => [];
 
     protected abstract Task<TSearchResults> GetSearchResults(TSearchQuery query);
 

--- a/src/Rested.Core.MediatR/Queries/SearchQuery.cs
+++ b/src/Rested.Core.MediatR/Queries/SearchQuery.cs
@@ -101,11 +101,12 @@ public abstract class SearchQueryValidator<TResultType, TSearchResults, TSearchQ
             .LessThanOrEqualTo(query => query.MaxPageSize)
             .WithServiceErrorCode(ServiceErrorCodes.CommonErrorCodes.PageSizeMustBeLessThanOrEqualToMaxPageSize, query => [query.MaxPageSize]);
 
-        When(
-            predicate: query => query.SearchRequest.SortingFields is not null,
-            action: () => RuleForEach(query => query.SearchRequest.SortingFields).SetValidator(new FieldSortInfoValidator(validFieldNames, ignoredFieldNames, ServiceErrorCodes)));
-
-        RuleFor(query => query.SearchRequest.Filters).SetValidator(new FiltersValidator(validFieldNames, ignoredFieldNames, ServiceErrorCodes));
+        RuleForEach(query => query.SearchRequest.SortingFields)
+            .SetValidator(_ => new FieldSortInfoValidator(validFieldNames, ignoredFieldNames, ServiceErrorCodes))
+            .When(query => query.SearchRequest.SortingFields is not null && query.SearchRequest.SortingFields.Count > 0);
+        
+        RuleFor(query => query.SearchRequest.Filters)
+            .SetValidator(_ => new FiltersValidator(validFieldNames, ignoredFieldNames, ServiceErrorCodes));
     }
 
     #endregion Ctor

--- a/src/Rested.Core.MediatR/Queries/Validators/FieldFilterValidator.cs
+++ b/src/Rested.Core.MediatR/Queries/Validators/FieldFilterValidator.cs
@@ -1,5 +1,5 @@
-using System.Text.RegularExpressions;
 using FluentValidation;
+using Rested.Core.Data;
 using Rested.Core.Data.Search;
 using Rested.Core.MediatR.Validation;
 
@@ -19,21 +19,8 @@ public abstract class FieldFilterValidator<TFieldFilter> : AbstractValidator<TFi
             action: () =>
             {
                 RuleFor(fieldFilter => fieldFilter)
-                    .Must(fieldFilter => IsFieldNameValid(fieldFilter.FieldName, validFieldNames, ignoredFieldNames))
+                    .Must(fieldFilter => DataUtility.IsFieldNameValid(fieldFilter.FieldName, validFieldNames, ignoredFieldNames))
                     .WithServiceErrorCode(serviceErrorCodes.CommonErrorCodes.FieldFilterNameIsInvalid);
             });
-    }
-
-    private static bool IsFieldNameValid(string fieldName, IEnumerable<string> validFieldNames, IEnumerable<string> ignoredFieldNames)
-    {
-        fieldName = Regex.Replace(
-            input: fieldName,
-            pattern: @"\[.*?\]",
-            replacement: "");
-
-        var doesFieldNameExist = validFieldNames.Contains(fieldName);
-        var isFieldNameIgnored = ignoredFieldNames.Contains(fieldName);
-
-        return doesFieldNameExist && !isFieldNameIgnored;
     }
 }

--- a/src/Rested.Core.MediatR/Queries/Validators/FieldSortInfoValidator.cs
+++ b/src/Rested.Core.MediatR/Queries/Validators/FieldSortInfoValidator.cs
@@ -1,8 +1,7 @@
 ﻿using FluentValidation;
 using Rested.Core.Data;
-using Rested.Core.MediatR.Validation;
-using System.Text.RegularExpressions;
 using Rested.Core.Data.Search;
+using Rested.Core.MediatR.Validation;
 
 namespace Rested.Core.MediatR.Queries.Validators;
 
@@ -19,21 +18,8 @@ public class FieldSortInfoValidator : AbstractValidator<FieldSortInfo>
             action: () =>
             {
                 RuleFor(fieldSortInfo => fieldSortInfo)
-                    .Must(m => IsFieldNameValid(m.FieldName, validFieldNames, ignoredFieldNames))
+                    .Must(m => DataUtility.IsFieldNameValid(m.FieldName, validFieldNames, ignoredFieldNames))
                     .WithServiceErrorCode(serviceErrorCodes.CommonErrorCodes.SortingFieldNameIsInvalid);
             });
-    }
-
-    protected bool IsFieldNameValid(string fieldName, IEnumerable<string> validFieldNames, IEnumerable<string> ignoredFieldNames)
-    {
-        fieldName = Regex.Replace(
-            input: fieldName,
-            pattern: @"\[.*?\]",
-            replacement: "");
-
-        bool doesFieldNameExist = validFieldNames.Contains(fieldName);
-        bool isFieldNameIgnored = ignoredFieldNames.Contains(fieldName);
-
-        return doesFieldNameExist && !isFieldNameIgnored;
     }
 }


### PR DESCRIPTION
Updated FieldName validation logic to now match against expected Regex patterns. Valid/Invalid field names are still generated from a property tree, however the field names are stored as Regex patterns.

Also addressed issue with validating field names that defined an array indexer in the path.

Changed the SortingFields and Filters properties to be nullable to avoid MVC validation superseding Fluent Validation. This prevents the MVC "property is required" error when a request does have any of the properties present in the request.